### PR TITLE
Logging timestamp

### DIFF
--- a/run.py
+++ b/run.py
@@ -6,6 +6,7 @@ from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.common.exceptions import WebDriverException
 import chromedriver_binary
+from datetime import datetime
 
 import config
 from slots import SlotElement
@@ -159,6 +160,8 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     logging.basicConfig(
+        format='%(asctime)s %(levelname)-8s %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S',
         level=logging.INFO if not args.debug else logging.DEBUG
     )
     log.info('Invoking Selenium Chrome webdriver')

--- a/run.py
+++ b/run.py
@@ -6,7 +6,6 @@ from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.common.exceptions import WebDriverException
 import chromedriver_binary
-from datetime import datetime
 
 import config
 from slots import SlotElement


### PR DESCRIPTION
When I was wondering today how long it actually took me to get the stupid delivery window, I have realized that there's no easy way to see that from logs. Also it's sometimes hard to have a visual confirmation that the code is still running and not frozen.
So I propose to add a timestamp to all log messages, as it will fix both. Obviously very minor and completely up to you. 