### PR TITLE
Write debug dump using utf-8.

### DIFF
--- a/deliverance/utils.py
+++ b/deliverance/utils.py
@@ -38,7 +38,7 @@ def dump_source(driver):
         timestamp()
     )
     log.info('Dumping page source to: ' + filename)
-    with open(filename, 'w') as f:
+    with open(filename, 'w', encoding='utf-8') as f:
         f.write(driver.page_source)
 
 

--- a/deliverance/utils.py
+++ b/deliverance/utils.py
@@ -58,7 +58,7 @@ def save_removed_items(driver):
     else:
         fp = 'removed_items_{}.toml'.format(timestamp())
         log.info('Writing {} removed items to: {}'.format(len(removed), fp))
-        with open(fp, 'w') as f:
+        with open(fp, 'w', encoding='utf-8') as f:
             toml.dump({'items': removed}, f)
 
 


### PR DESCRIPTION
Prevents such errors:

```
Traceback (most recent call last):
  File "run.py", line 188, in <module>
    dump_source(driver)
  File "D:\amazon\deliverance\utils.py", line 42, in dump_source
    f.write(driver.page_source)
UnicodeEncodeError: 'gbk' codec can't encode character '\xa9' in position 469929: illegal multibyte sequence
```